### PR TITLE
Downgrade Docker to 27.5.1 for Jetson compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ bash ./configure_nvidia_docker.sh
 ```
 
 ## Release Notes
+### February 22, 2025
+An issue with Docker 28.0.0 (released 2/20/2025) requires changes to the kernel:
+
+CONFIG_IP_SET=m
+CONFIG_IP_SET_HASH_NET=m
+CONFIG_NETFILTER_XT_SET=m
+
+The current work around is to downgrade to Docker 27.5.1. Also, Docker is marked hold so that apt upgrade doesn't inadvertently upgrade the package.
+  
 ### February 2025
 * Initial Release
 * Tested on NVIDIA Jetson Orin Nano Super Developer Kit

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ bash ./configure_nvidia_docker.sh
 ## Release Notes
 ### February 22, 2025
 An issue with Docker 28.0.0 (released 2/20/2025) requires changes to the kernel:
-
+```
 CONFIG_IP_SET=m
 CONFIG_IP_SET_HASH_NET=m
 CONFIG_NETFILTER_XT_SET=m
-
-The current work around is to downgrade to Docker 27.5.1. Also, Docker is marked hold so that apt upgrade doesn't inadvertently upgrade the package.
+```
+The install_nvidia_docker.sh script incorporates the current work around which is to downgrade to Docker 27.5.1. Also, Docker is marked hold so that apt upgrade doesn't inadvertently upgrade the package.
   
 ### February 2025
 * Initial Release

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ bash ./configure_nvidia_docker.sh
 
 ## Release Notes
 ### February 22, 2025
-An issue with Docker 28.0.0 (released 2/20/2025) requires changes to the kernel:
+An issue with Docker 28.0.0 (released 2/20/2025) requires changes to the kernel which are not implemented in the current Jetson 6.2 release:
 ```
 CONFIG_IP_SET=m
 CONFIG_IP_SET_HASH_NET=m
 CONFIG_NETFILTER_XT_SET=m
 ```
 The install_nvidia_docker.sh script incorporates the current work around which is to downgrade to Docker 27.5.1. Also, Docker is marked hold so that apt upgrade doesn't inadvertently upgrade the package.
+Apparently the settings are forward in the Ubuntu 24.04, and are not implemented in the Jetson 22.04 derived OS.
   
 ### February 2025
 * Initial Release

--- a/install_nvidia_docker.sh
+++ b/install_nvidia_docker.sh
@@ -31,6 +31,14 @@ chmod +x docker_install.sh
 # Install Docker.
 sudo ./docker_install.sh
 
+# An issue with the current Docker 28.0.0 requires a different set of kernel modules to be enabled.
+# The JetPack 6.2 release of Jetson doesn't support these. So we downgrade
+sudo apt-get install -y docker-ce=5:27.5.1-1~ubuntu.22.04~jammy --allow-downgrades
+sudo apt-get install -y docker-ce-cli=5:27.5.1-1~ubuntu.22.04~jammy --allow-downgrades
+# The we mark them so they do not get upgraded with apt upgrade
+sudo apt-mark hold docker-ce=5:27.5.1-1~ubuntu.22.04~jammy
+sudo apt-mark hold docker-ce-cli=5:27.5.1-1~ubuntu.22.04~jammy
+
 rm docker_install.sh
 
 # Enable and start the Docker service.


### PR DESCRIPTION
Docker 28.0.0 requires kernel modules which are not present in the Jetson kernel for JetPack 6.2.
These changes downgrade to 27.5.1, and marks the packages held so that they are not upgraded by
the apt upgrade process.